### PR TITLE
Add dark mode toggle functionality

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
-import { Menu, Button } from 'semantic-ui-react';
+import { Menu, Button, Icon } from 'semantic-ui-react';
+import useDarkMode from '../../hooks/useDarkMode';
 
 const Header = () => {
   const [promptEvent, setPromptEvent] = useState(null);
   const [appAccepted, setAppAccepted] = useState(false);
+  const [isDarkMode, toggleDarkMode] = useDarkMode();
 
   let isAppInstalled = false;
 
@@ -33,17 +35,27 @@ const Header = () => {
       <Menu.Item header>
         <h1>QuizApp</h1>
       </Menu.Item>
-      {promptEvent && !isAppInstalled && (
-        <Menu.Item position="right">
+      <Menu.Item position="right">
+        <Button
+          icon
+          basic
+          inverted
+          onClick={toggleDarkMode}
+          title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          <Icon name={isDarkMode ? 'sun' : 'moon'} />
+        </Button>
+        {promptEvent && !isAppInstalled && (
           <Button
             color="teal"
             icon="download"
             labelPosition="left"
             content="Install App"
             onClick={installApp}
+            style={{ marginLeft: '10px' }}
           />
-        </Menu.Item>
-      )}
+        )}
+      </Menu.Item>
     </Menu>
   );
 };

--- a/src/hooks/useDarkMode.js
+++ b/src/hooks/useDarkMode.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+const useDarkMode = () => {
+  const [isDarkMode, setIsDarkMode] = useState(() => {
+    const savedTheme = localStorage.getItem('theme');
+    return savedTheme === 'dark';
+  });
+
+  useEffect(() => {
+    const theme = isDarkMode ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [isDarkMode]);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode(prevMode => !prevMode);
+  };
+
+  return [isDarkMode, toggleDarkMode];
+};
+
+export default useDarkMode;

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,58 @@
 @import url(../node_modules/semantic-ui-css/semantic.min.css);
+
+:root {
+  --background-color: #ffffff;
+  --text-color: #1b1c1d;
+  --header-background: #1b1c1d;
+  --header-text: #ffffff;
+  --card-background: #ffffff;
+  --border-color: rgba(34,36,38,.15);
+  --shadow: 0 1px 3px 0 #d4d4d5, 0 0 0 1px #d4d4d5;
+}
+
+[data-theme="dark"] {
+  --background-color: #1a1a1a;
+  --text-color: #ffffff;
+  --header-background: #2a2a2a;
+  --header-text: #ffffff;
+  --card-background: #2a2a2a;
+  --border-color: rgba(255,255,255,.15);
+  --shadow: 0 1px 3px 0 rgba(0,0,0,.3), 0 0 0 1px rgba(255,255,255,.1);
+}
+
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.ui.inverted.menu {
+  background: var(--header-background);
+}
+
+.ui.card,
+.ui.cards > .card {
+  background: var(--card-background);
+  box-shadow: var(--shadow);
+  color: var(--text-color);
+}
+
+.ui.segment {
+  background: var(--card-background);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+}
+
+.ui.button {
+  transition: all 0.3s ease;
+}
+
+[data-theme="dark"] .ui.button:not(.primary):not(.secondary):not(.positive):not(.negative):not(.teal) {
+  background: var(--card-background);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .ui.button:not(.primary):not(.secondary):not(.positive):not(.negative):not(.teal):hover {
+  background: rgba(255,255,255,0.1);
+}


### PR DESCRIPTION
Implements dark mode toggle button in the top right of the header as requested in #1.

## Changes
- Added CSS variables for light/dark theme support
- Created useDarkMode hook with localStorage persistence
- Added toggle button with moon/sun icons in header
- Implemented smooth transitions between themes

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)